### PR TITLE
Load modules based on new MESA build system

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,14 @@ Any post github version: that is a version that starts with 'r2' or is from a gi
 
 Make sure you set ``MESA_DIR`` and ``MESASDK_ROOT`` before starting Python.
 
+If you recieve a Python ``CalledProcessError`` then in your shell set the enviromenet variable
+````
+FC=$MESASDK_ROOT/bin/gfortran
+````
+
+There is an issue where the gfortran.wrapper is found instead of the gfortran compilier and
+we dont pass arguments correctly.
+
 
 ## Usage
 

--- a/mesa_models/eos.py
+++ b/mesa_models/eos.py
@@ -51,7 +51,7 @@ eos_result = eos_lib.eosdt_get(
     ierr
 )
 
-if res.args['ierr'] != 0:
+if eos_result.args['ierr'] != 0:
     raise ValueError("Ierr not zero eosdt_get")
 
 # The EOS call returns the quantities we want in the "res" array.

--- a/mesa_models/kap.py
+++ b/mesa_models/kap.py
@@ -75,7 +75,7 @@ eos_result = eos_lib.eosdt_get(
     ierr
 )
 
-if res.args['ierr'] != 0:
+if eos_result.args['ierr'] != 0:
     raise ValueError("Ierr not zero eosdt_get")
 
 
@@ -103,7 +103,7 @@ kap_res = kap_lib.kap_get(kap_handle, species, chem_id, net_iso, xa,
                           kap_fracs, kap, dlnkap_dlnRho, dlnkap_dlnT, dlnkap_dxa,
                           ierr)
 
-if res.args['ierr'] != 0:
+if kap_res.args['ierr'] != 0:
     raise ValueError("Ierr not zero from kap_get")
 
 print(f"Opacity {kap_res.args['kap']}")

--- a/pyMesa/__init__.py
+++ b/pyMesa/__init__.py
@@ -1,1 +1,15 @@
-from .pyMesaUtils import *
+
+import pathlib
+import os
+
+if "MESA_DIR" not in os.environ:
+    raise ValueError("Must set MESA_DIR environment variable")
+else:
+    MESA_DIR = os.environ.get('MESA_DIR')
+
+if pathlib.Path(MESA_DIR).joinpath('build'):
+    #Post 2026 versions
+    from .pyMesaUtils_2026 import *
+else:
+    # Older MESA's pre 2026
+    from .pyMesaUtils_pre2026 import *

--- a/pyMesa/__init__.py
+++ b/pyMesa/__init__.py
@@ -7,7 +7,7 @@ if "MESA_DIR" not in os.environ:
 else:
     MESA_DIR = os.environ.get('MESA_DIR')
 
-if pathlib.Path(MESA_DIR).joinpath('build'):
+if pathlib.Path(MESA_DIR).joinpath('build').exists():
     #Post 2026 versions
     from .pyMesaUtils_2026 import *
 else:

--- a/pyMesa/pyMesaUtils_2026.py
+++ b/pyMesa/pyMesaUtils_2026.py
@@ -1,0 +1,113 @@
+# SPDX-License-Identifier: GPL-2.0+
+
+import gfort2py as gf
+import os
+import sys
+import shutil
+import subprocess
+
+
+#MESA DIR check and path set
+if "MESA_DIR" not in os.environ:
+    raise ValueError("Must set MESA_DIR environment variable")
+else:
+    MESA_DIR = os.environ.get('MESA_DIR')
+
+
+DATA_DIR = os.path.join(MESA_DIR,'data')
+BUILD_DIR = os.path.join(MESA_DIR,'build')
+INCLUDE_DIR = os.path.join(MESA_DIR,'include')
+
+RATES_DATA=os.path.join(DATA_DIR,'rates_data')
+EOSDT_DATA=os.path.join(DATA_DIR,'eosDT_data')
+EOSPT_DATA=os.path.join(DATA_DIR,'eosPT_data')
+ION_DATA=os.path.join(DATA_DIR,'ionization_data')
+KAP_DATA=os.path.join(DATA_DIR,'kap_data')
+
+NET_DATA=os.path.join(DATA_DIR,'net_data')
+
+RATES_CACHE=os.path.join(RATES_DATA,'cache')
+EOSDT_CACHE=os.path.join(EOSDT_DATA,'cache')
+EOSPT_CACHE=os.path.join(EOSPT_DATA,'cache')
+ION_CACHE=os.path.join(ION_DATA,'cache')
+KAP_CACHE=os.path.join(KAP_DATA,'cache')
+NETS=os.path.join(NET_DATA,'nets')
+
+MESASDK_ROOT=os.path.expandvars('$MESASDK_ROOT')
+
+with open(os.path.join(DATA_DIR,'version_number'),'r') as f:
+    v=f.readline().strip()
+    if not v.startswith('r2') and len(v)<7:
+        raise ValueError(f"Unsupported MESA version {v}")
+
+
+p=sys.platform.lower()
+
+if p == "linux" or p == "linux2":
+    LIB_EXT='so'
+elif p == "darwin":
+    LIB_EXT="dylib"
+else:
+    raise Exception(f"Platform not support {p}")
+
+# The one function you actually need
+def loadMod(module):
+
+    MODULE_LIB = os.path.join(BUILD_DIR,module,'include',f"{module}_lib.mod")
+    MODULE_DEF = os.path.join(BUILD_DIR,module,'include',f"{module}_def.mod")
+
+    if module =='run_star_support':
+         SHARED_LIB = os.path.join(BUILD_DIR,f"librun_star_support.{LIB_EXT}")
+         MODULE_LIB = os.path.join(INCLUDE_DIR,"run_star_support.mod")
+    elif module =='run_star_extras':
+         SHARED_LIB = os.path.join(BUILD_DIR,f"librun_star_extras.{LIB_EXT}")
+         MODULE_LIB = os.path.join(INCLUDE_DIR,"run_star_extras.mod")
+    else:
+        SHARED_LIB = os.path.join(BUILD_DIR,module,'lib',f"lib{module}.{LIB_EXT}")
+
+    x = None
+    y = None
+
+    try:
+        x = gf.fFort(SHARED_LIB,MODULE_LIB)
+    except FileNotFoundError:
+        pass
+
+    try:
+        y = gf.fFort(SHARED_LIB,MODULE_DEF)
+    except FileNotFoundError:
+        pass
+
+    return x, y
+
+
+def _buildRunStarSupport():
+    raise NotImplementedError("Building run star support no longer supported")
+
+
+def _buildRunStarExtras(rse=None):
+    raise NotImplementedError("Building run star extras no longer supported")
+
+class MesaError(Exception):
+    pass
+
+
+def _checkcrpath():
+	res = subprocess.call(["command","-v","chrpath"])
+	if res:
+		raise ValueError("Please install chrpath")
+
+
+def make_basic_inlist():
+	with open('inlist','w') as f:
+		print('&star_job',file=f)
+		print('/',file=f)
+		print('&controls',file=f)
+		print('/',file=f)
+		print('&pgstar',file=f)
+		print('/',file=f)
+
+
+def mesa_init():
+    _buildRunStarExtras()
+    _buildRunStarSupport()

--- a/pyMesa/pyMesaUtils_2026.py
+++ b/pyMesa/pyMesaUtils_2026.py
@@ -13,6 +13,11 @@ if "MESA_DIR" not in os.environ:
 else:
     MESA_DIR = os.environ.get('MESA_DIR')
 
+# Gfort2py version check
+if not gf.__version__.startswith('3.'):
+    raise ValueError(f"Unsupported gfort2py version {gf.__version__}, must be greater than 3.0.0")
+
+
 
 DATA_DIR = os.path.join(MESA_DIR,'data')
 BUILD_DIR = os.path.join(MESA_DIR,'build')

--- a/pyMesa/pyMesaUtils_2026.py
+++ b/pyMesa/pyMesaUtils_2026.py
@@ -71,6 +71,9 @@ def loadMod(module):
     try:
         x = gf.fFort(SHARED_LIB,MODULE_LIB)
     except FileNotFoundError:
+        # Check if static library exists, if so warn
+        if os.path.exists(os.path.join(BUILD_DIR,module,'lib',f"lib{module}.a")):
+            raise MesaError(f"Shared library for {module} not found, but static library exists. Please build with shared libraries enabled.")
         pass
 
     try:

--- a/pyMesa/pyMesaUtils_pre2026.py
+++ b/pyMesa/pyMesaUtils_pre2026.py
@@ -1,21 +1,4 @@
-# Tool to build mesa with python support
-
-# Copyright (C) 2023  Robert Farmer <robert.j.farmer37@gmail.com>
-
-#This file is part of pyMesa.
-
-#pyMesa is free software: you can redistribute it and/or modify
-#it under the terms of the GNU General Public License as published by
-#the Free Software Foundation, either version 2 of the License, or
-#(at your option) any later version.
-
-#pyMesa is distributed in the hope that it will be useful,
-#but WITHOUT ANY WARRANTY; without even the implied warranty of
-#MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#GNU General Public License for more details.
-
-#You should have received a copy of the GNU General Public License
-#along with pyMesa. If not, see <http://www.gnu.org/licenses/>.
+# SPDX-License-Identifier: GPL-2.0+
 
 import gfort2py as gf
 import os

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-gfort2py>=2.6.2
+gfort2py>=3.0.0


### PR DESCRIPTION
Works on https://github.com/MESAHub/mesa/pull/908 though also needs likely needs https://github.com/MESAHub/mesa/pull/905

Any module that depends on utils wont load with an error:

````
OSError: libutils.so: cannot enable executable stack as shared object requires: Invalid argument
````

which is most modules. But at least const loads so we can very accurately know what 2/3 is:
````
const_def.two_thirds
np.float64(0.6666666666666666)
````